### PR TITLE
Gjør komponenter kompatible med SSR

### DIFF
--- a/packages/webpack.base.js
+++ b/packages/webpack.base.js
@@ -22,6 +22,7 @@ module.exports = {
     output: {
         filename: 'index.js',
         libraryTarget: 'umd',
+        globalObject: 'this',
         umdNamedDefine: true
     },
     externals: {


### PR DESCRIPTION
Før krasjet det med wndow is not defined ved ssr.

Fra webpack docs: To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'
https://webpack.js.org/configuration/output/#outputglobalobject